### PR TITLE
Fix charmap error by encoding with utf8

### DIFF
--- a/src/markdown.py
+++ b/src/markdown.py
@@ -18,7 +18,7 @@ logging.basicConfig(
 
 def read_file(path: str) -> str:
     """ read file from path """
-    with open(path) as input_file:
+    with open(path, encoding="utf8") as input_file:
         data = input_file.read()
         return data
 


### PR DESCRIPTION
This is with regard to the charmap error that Windows users were getting.

## What is the current behavior?

After the markdown gets encoded, when the decoding happens, some unicode is undefined, due to a difference in the encoding structure. As a result, some people can't load the reflection markdown documents.

## What is the new behavior if this PR is merged?

People will be able to load the reflection markdown documents.

## Type of change

Please describe the pull request as one of the following:

- [x] Bug fix
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation update
- [ ] Other <!-- Please specify any helpful information below -->

### Other information

### This PR has:

- [x] Commit messages that are correctly formatted
- [ ] Tests for newly introduced code
- [ ] Docstrings for newly introduced code

#### Developers

@Coleman
