### PR TITLE
Fix #40 : images not appearing on the streamlit home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Network URL: http://xxx.xxx.x.x:8501
 
 The web interface will be automatically opened in your browser:
 
-![browser](resources/images/landing_page.png)
+<img src="resources/images/landing_page.png" alt="browser" style="width:100%"/>
 
 ### Data Retreiving
 
@@ -113,7 +113,7 @@ with GatorGrader [here](https://github.com/enpuyou/script-api-lambda-dynamodb).
 Once the documents are successfully imported, you can then navigate through
 the select box in the sidebar to view the text analysis:
 
-![select box](resources/images/select_box.png)
+<img src="resources/images/select_box.png" alt="select box" style="width:100%"/>
 
 ##### Reflection Documents
 
@@ -132,10 +132,10 @@ format of json reports GatorMiner gathers from AWS.
 
 ### Analysis
 
-![frequency](resources/images/frequency.png)
-![sentiment](resources/images/sentiment.png)
-![similarity](resources/images/similarity.png)
-![topic](resources/images/topic.png)
+<img src="resources/images/frequency.png" alt="frequency" style="width:100%"/>
+<img src="resources/images/sentiment.png" alt="sentiment" style="width:100%"/>
+<img src="resources/images/similarity.png" alt="similarity" style="width:100%"/>
+<img src="resources/images/topic.png" alt="topic" style="width:100%"/>
 
 ### Contribution
 

--- a/streamlit_web.py
+++ b/streamlit_web.py
@@ -125,7 +125,7 @@ documents(seperate by comma)"
             "You will need to store keys and endpoints in the \
 environment variables")
     if not input_assignments:
-        readme()
+        landing_pg()
     else:
         input_assignments = re.split(r"[;,\s]\s*", input_assignments)
         try:

--- a/streamlit_web.py
+++ b/streamlit_web.py
@@ -62,7 +62,7 @@ def main():
         if debug_mode:
             st.write(main_df)
         if analysis_mode == "Home":
-            landing_pg()
+            readme()
         else:
             if analysis_mode == "Frequency Analysis":
                 st.title(analysis_mode)

--- a/streamlit_web.py
+++ b/streamlit_web.py
@@ -2,7 +2,9 @@
 
 import re
 
+import base64
 import numpy as np
+import os
 import pandas as pd
 from sklearn.manifold import TSNE
 import spacy
@@ -89,7 +91,14 @@ def landing_pg():
     landing = st.sidebar.selectbox("Welcome", ["Home", "Interactive"])
     if landing == "Home":
         with open("README.md") as readme_file:
-            st.markdown(readme_file.read())
+            readme_src = readme_file.read()
+            for file in os.listdir("resources/images"):
+                if file.endswith(".png"):
+                    img_path = f"resources/images/{file}"
+                    with open(img_path, "rb") as f:
+                        img_bin = base64.b64encode(f.read()).decode()
+                    readme_src = readme_src.replace(img_path, f"data:image/png;base64,{img_bin}")
+            st.markdown(readme_src, unsafe_allow_html=True)
     else:
         interactive()
 

--- a/streamlit_web.py
+++ b/streamlit_web.py
@@ -84,20 +84,26 @@ def main():
                 interactive()
             success_msg.empty()
 
+def readme():
+    """function to load and configurate readme source"""
+
+    with open("README.md") as readme_file:
+        readme_src = readme_file.read()
+        for file in os.listdir("resources/images"):
+            if file.endswith(".png"):
+                img_path = f"resources/images/{file}"
+                with open(img_path, "rb") as f:
+                    img_bin = base64.b64encode(f.read()).decode()
+                readme_src = readme_src.replace(img_path, f"data:image/png;base64,{img_bin}")
+
+        st.markdown(readme_src, unsafe_allow_html=True)
 
 def landing_pg():
     """landing page"""
     landing = st.sidebar.selectbox("Welcome", ["Home", "Interactive"])
+
     if landing == "Home":
-        with open("README.md") as readme_file:
-            readme_src = readme_file.read()
-            for file in os.listdir("resources/images"):
-                if file.endswith(".png"):
-                    img_path = f"resources/images/{file}"
-                    with open(img_path, "rb") as f:
-                        img_bin = base64.b64encode(f.read()).decode()
-                    readme_src = readme_src.replace(img_path, f"data:image/png;base64,{img_bin}")
-            st.markdown(readme_src, unsafe_allow_html=True)
+        readme()
     else:
         interactive()
 
@@ -119,7 +125,7 @@ documents(seperate by comma)"
             "You will need to store keys and endpoints in the \
 environment variables")
     if not input_assignments:
-        landing_pg()
+        readme()
     else:
         input_assignments = re.split(r"[;,\s]\s*", input_assignments)
         try:
@@ -128,7 +134,7 @@ environment variables")
         except TypeError:
             st.sidebar.warning(
                 "No data imported. Please check the reflection document input")
-            landing_pg()
+            readme()
         else:
             global success_msg
             success_msg = None
@@ -164,7 +170,7 @@ def import_data(data_retreive_method, paths):
                 json_lst.append(md.collect_md(path))
         except FileNotFoundError as err:
             st.sidebar.text(err)
-            landing_pg()
+            readme()
     else:
         passbuild = st.sidebar.checkbox(
             "Only retreive build success records", value=True)
@@ -175,7 +181,7 @@ def import_data(data_retreive_method, paths):
                 json_lst.append(ju.clean_report(response))
         except (EnvironmentError, Exception) as err:
             st.sidebar.error(err)
-            landing_pg()
+            readme()
     # when data is retreived
     if json_lst:
         raw_df = pd.DataFrame()

--- a/streamlit_web.py
+++ b/streamlit_web.py
@@ -62,8 +62,7 @@ def main():
         if debug_mode:
             st.write(main_df)
         if analysis_mode == "Home":
-            with open("README.md") as readme_file:
-                st.markdown(readme_file.read())
+            landing_pg()
         else:
             if analysis_mode == "Frequency Analysis":
                 st.title(analysis_mode)
@@ -129,8 +128,7 @@ environment variables")
         except TypeError:
             st.sidebar.warning(
                 "No data imported. Please check the reflection document input")
-            with open("README.md") as readme_file:
-                st.markdown(readme_file.read())
+            landing_pg()
         else:
             global success_msg
             success_msg = None
@@ -166,8 +164,7 @@ def import_data(data_retreive_method, paths):
                 json_lst.append(md.collect_md(path))
         except FileNotFoundError as err:
             st.sidebar.text(err)
-            with open("README.md") as readme_file:
-                st.markdown(readme_file.read())
+            landing_pg()
     else:
         passbuild = st.sidebar.checkbox(
             "Only retreive build success records", value=True)
@@ -178,8 +175,7 @@ def import_data(data_retreive_method, paths):
                 json_lst.append(ju.clean_report(response))
         except (EnvironmentError, Exception) as err:
             st.sidebar.error(err)
-            with open("README.md") as readme_file:
-                st.markdown(readme_file.read())
+            landing_pg()
     # when data is retreived
     if json_lst:
         raw_df = pd.DataFrame()


### PR DESCRIPTION
Allow streamlit homepage to display images from resources/images/*.

## What is the current behavior?

#40 

## What is the new behavior if this PR is merged?

In order to solve the issue raised in #40 , all image paths were encoded to base64 and then the original path was replaced in the README.md string before calling the st.markdown() function. This allows streamlit to display the image on the home page.

PLEASE NOTE: other local files such as `CONTRIBUTING.md` are still not able to be viewed. If merged, a new issue would have to be opened regarding this.

## Type of change

Please describe the pull request as one of the following:

- [x] Bug fix
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation update
- [ ] Other <!-- Please specify any helpful information below -->

### Other information

Edits were made to the README.md to allow styling using HTML image tags rather that traditional markdown image embedding.

### This PR has:

- [x] Commit messages that are correctly formatted
- [ ] Tests for newly introduced code
- [x] Docstrings for newly introduced code

#### Developers

@caldwella2 @PaigeCD @connellyw @angusn8 @Nathandloria 
